### PR TITLE
Cleanup css code and switch trait aritthecture.

### DIFF
--- a/crates/natrix/src/css/keyframes.rs
+++ b/crates/natrix/src/css/keyframes.rs
@@ -2,6 +2,7 @@
 
 use super::values::IntoCss;
 use crate::css::prelude::RuleBody;
+use crate::css::values::CssPropertyValue;
 use crate::css::values::units::Percentage;
 
 /// The name of a keyframe
@@ -12,6 +13,10 @@ impl IntoCss for KeyFrame {
     fn into_css(self) -> String {
         super::as_css_identifier(self.0)
     }
+}
+
+impl CssPropertyValue for KeyFrame {
+    type Kind = KeyFrame;
 }
 
 /// A keyframe definition

--- a/crates/natrix/src/css/mod.rs
+++ b/crates/natrix/src/css/mod.rs
@@ -19,7 +19,7 @@ pub mod values;
 pub mod prelude {
     pub use super::property::RuleBody;
     pub use super::{IntoCss, property, selectors, values};
-    pub use crate::selector_list;
+    pub use crate::{const_unwrap, selector_list};
 }
 
 /// Convert a value to a css
@@ -292,8 +292,8 @@ mod tests {
         );
         crate::register_keyframe!(
             const SLIDE = KeyframeDefinition::new()
-            .frame(crate::unit!(0.0%), RuleBody::new().align_content(values::Normal))
-            .frame(crate::unit!(100.0%), RuleBody::new().align_content(values::Normal))
+            .frame(values::Percentage(0.0), RuleBody::new().align_content(values::Normal))
+            .frame(values::Percentage(100.0), RuleBody::new().align_content(values::Normal))
         );
 
         #[test]

--- a/crates/natrix/src/css/mod.rs
+++ b/crates/natrix/src/css/mod.rs
@@ -273,7 +273,7 @@ mod tests {
     mod test_collection {
         use crate::prelude::*;
 
-        const BUTTON_CLASS: crate::prelude::Class = crate::prelude::Class("btn"); // Consistent
+        const BUTTON_CLASS: crate::prelude::Class = crate::class!();
 
         crate::register_rule!(
             BUTTON_CLASS,

--- a/crates/natrix/src/css/property.rs
+++ b/crates/natrix/src/css/property.rs
@@ -283,3 +283,7 @@ support_no_test!(AspectRatio, (values::Auto, values::KindNumeric));
 test_property!(AspectRatio, (values::Auto, f32), auto_f32);
 support_no_test!(AspectRatio, (values::KindNumeric, values::Auto));
 test_property!(AspectRatio, (f32, values::Auto), f32_auto);
+
+property!(BackdropFilter => "backdrop-filter");
+support!(BackdropFilter, values::Filter, filter);
+test_property!(BackdropFilter, Vec<values::Filter>, filter_vec);

--- a/crates/natrix/src/css/values.rs
+++ b/crates/natrix/src/css/values.rs
@@ -417,6 +417,10 @@ impl IntoCss for EasingFunction {
     }
 }
 
+impl CssPropertyValue for EasingFunction {
+    type Kind = EasingFunction;
+}
+
 /// The `animation-iteration-count` value.
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/animation-iteration-count>
 #[derive(Debug, Clone, Copy)]
@@ -445,6 +449,10 @@ impl IntoCss for AnimationIterationCount {
             Self::Finite(value) => value.to_string(),
         }
     }
+}
+
+impl CssPropertyValue for AnimationIterationCount {
+    type Kind = AnimationIterationCount;
 }
 
 define_enum! {

--- a/crates/natrix/src/css/values.rs
+++ b/crates/natrix/src/css/values.rs
@@ -17,6 +17,37 @@ use crate::css::values::units::Angle;
 use crate::error_handling::{log_or_panic, log_or_panic_result};
 use crate::type_macros;
 
+/// Define a css shorthand property.
+/// auto creating the setters, and allowing non-setter based fields.
+macro_rules! define_css_shorthand {
+    (
+        $(#[$meta:meta])*
+        pub struct
+        $name:ident {
+            $(#[$($d_custom:meta)*] $f_custom_n:ident : $f_custom_t:ty),* $(,)? { $(#[$($d:meta)*] $f_n:ident : $f_t:ty),* $(,)? }
+        }
+    ) => {
+        $(#[$meta])*
+        #[derive(Clone, Debug)]
+        #[must_use]
+        pub struct $name {
+            $(#[$($d_custom)*] $f_custom_n: $f_custom_t),*,
+            $(#[$($d)*] $f_n: String),*
+        }
+
+        impl $name {
+            $(
+            #[$($d)*]
+            pub fn $f_n(mut self, value: impl CssPropertyValue<Kind = $f_t>) -> Self {
+                self.$f_n = value.into_css();
+                self
+            }
+        )*
+        }
+    };
+}
+use define_css_shorthand;
+
 /// Force a unwrap to happen at const time.
 /// If the value isnt a valid const expression this wont compile.
 ///

--- a/crates/natrix/src/css/values/animations.rs
+++ b/crates/natrix/src/css/values/animations.rs
@@ -13,26 +13,28 @@ pub use crate::css::values::{
     EasingFunction,
 };
 
-/// A css animation with all value components stored as raw CSS strings.
-#[must_use]
-#[derive(Debug, Clone)]
-pub struct Animation {
-    /// The animation-name
-    name: String,
-    /// The duration
-    duration: String,
-    /// The timing / easing function
-    easing: String,
-    /// The delay before it starts
-    delay: String,
-    /// The iteration count
-    iteration_count: String,
-    /// The direction
-    direction: String,
-    /// The fill-mode
-    fill_mode: String,
-    /// The play state
-    state: String,
+super::define_css_shorthand! {
+    /// A css animation
+    pub struct Animation {
+        /// <https://developer.mozilla.org/en-US/docs/Web/CSS/animation-name>
+        name: String,
+        {
+            /// <https://developer.mozilla.org/en-US/docs/Web/CSS/animation-duration>
+            duration: Duration,
+            /// <https://developer.mozilla.org/en-US/docs/Web/CSS/animation-easing>
+            easing: EasingFunction,
+            /// <https://developer.mozilla.org/en-US/docs/Web/CSS/animation-delay>
+            delay: Duration,
+            /// <https://developer.mozilla.org/en-US/docs/Web/CSS/animation-iteration-count>
+            iteration_count: AnimationIterationCount,
+            /// <https://developer.mozilla.org/en-US/docs/Web/CSS/animation-direction>
+            direction: AnimationDirection,
+            /// <https://developer.mozilla.org/en-US/docs/Web/CSS/animation-fill-mode>
+            fill_mode: AnimationFillMode,
+            /// <https://developer.mozilla.org/en-US/docs/Web/CSS/animation-state>
+            state: AnimationState,
+        }
+    }
 }
 
 impl KeyFrame {
@@ -59,71 +61,10 @@ impl Animation {
             state: AnimationState::default().into_css(),
         }
     }
-
-    /// Override / set the animation name.
-    pub fn name(mut self, name: impl CssPropertyValue<Kind = KeyFrame>) -> Self {
-        self.name = name.into_css();
-        self
-    }
-
-    /// Set the time before the animation starts.
-    pub fn delay(mut self, delay: impl CssPropertyValue<Kind = Duration>) -> Self {
-        self.delay = delay.into_css();
-        self
-    }
-
-    /// Set the duration.
-    pub fn duration(mut self, duration: impl CssPropertyValue<Kind = Duration>) -> Self {
-        self.duration = duration.into_css();
-        self
-    }
-
-    /// Set the easing / timing function.
-    pub fn easing(mut self, function: impl CssPropertyValue<Kind = EasingFunction>) -> Self {
-        self.easing = function.into_css();
-        self
-    }
-
-    /// Set the iteration count.
-    pub fn iteration_count(
-        mut self,
-        count: impl CssPropertyValue<Kind = AnimationIterationCount>,
-    ) -> Self {
-        self.iteration_count = count.into_css();
-        self
-    }
-
-    /// Convenience: make this animation repeat forever.
-    pub fn infinite(mut self) -> Self {
-        self.iteration_count = AnimationIterationCount::Infinite.into_css();
-        self
-    }
-
-    /// Set the direction of the animation.
-    pub fn direction(
-        mut self,
-        direction: impl CssPropertyValue<Kind = AnimationDirection>,
-    ) -> Self {
-        self.direction = direction.into_css();
-        self
-    }
-
-    /// Set the animation fill-mode.
-    pub fn fill_mode(mut self, mode: impl CssPropertyValue<Kind = AnimationFillMode>) -> Self {
-        self.fill_mode = mode.into_css();
-        self
-    }
-
-    /// Set whether the animation is running or not.
-    pub fn state(mut self, state: impl CssPropertyValue<Kind = AnimationState>) -> Self {
-        self.state = state.into_css();
-        self
-    }
 }
 
 impl IntoCss for Animation {
     fn into_css(self) -> String {
-        // Order: duration | timing-function | delay | iteration-count | direction | fill-mode | play-state | name
         format!(
             "{} {} {} {} {} {} {} {}",
             self.duration,

--- a/crates/natrix/src/css/values/animations.rs
+++ b/crates/natrix/src/css/values/animations.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use crate::css::IntoCss;
 use crate::css::keyframes::KeyFrame;
+use crate::css::values::CssPropertyValue;
 pub use crate::css::values::{
     AnimationDirection,
     AnimationFillMode,
@@ -129,4 +130,11 @@ impl IntoCss for Vec<Animation> {
             .collect::<Vec<_>>()
             .join(", ")
     }
+}
+
+impl CssPropertyValue for Animation {
+    type Kind = Animation;
+}
+impl CssPropertyValue for Vec<Animation> {
+    type Kind = Animation;
 }

--- a/crates/natrix/src/css/values/colors.rs
+++ b/crates/natrix/src/css/values/colors.rs
@@ -1,6 +1,7 @@
 //! Implementation for css colors
 
 use super::IntoCss;
+use crate::css::values::CssPropertyValue;
 
 /// A css color
 ///
@@ -46,11 +47,14 @@ pub enum Color {
 }
 
 impl Color {
-    /// Set the alpha and return a new color
-    pub const fn with_alpha(self, alpha: f32) -> Self {
-        debug_assert!(alpha <= 1.0 && alpha >= 0.0, "Alpha should between 0-1");
+    /// Set the alpha and return a new color, or None if alpha is out of range [0, 1]
+    #[must_use]
+    pub const fn with_alpha(self, alpha: f32) -> Option<Self> {
+        if !(alpha >= 0.0 && alpha <= 1.0) {
+            return None;
+        }
 
-        match self {
+        Some(match self {
             Self::Rgb {
                 red,
                 green,
@@ -84,51 +88,57 @@ impl Color {
                 hue,
                 alpha,
             },
-        }
+        })
     }
 
-    /// Rgb with opaque alpha
+    /// Rgb with opaque alpha. This cannot fail.
     #[inline]
     pub const fn rgb(red: u8, green: u8, blue: u8) -> Self {
-        Self::rgba(red, green, blue, 1.0)
-    }
-
-    /// Rgb with alpha
-    #[inline]
-    pub const fn rgba(red: u8, green: u8, blue: u8, alpha: f32) -> Self {
-        debug_assert!(alpha <= 1.0 && alpha >= 0.0, "Alpha should be in range 0-1");
-
-        Color::Rgb {
+        Self::Rgb {
             red,
             green,
             blue,
-            alpha,
+            alpha: 1.0,
         }
     }
 
-    /// Hsl with opaque alpha
+    /// Rgb with alpha. Returns None if alpha is out of range [0, 1].
     #[inline]
-    pub const fn hsl(hue: u16, saturation: u8, lightness: u8) -> Self {
-        Self::hsla(hue, saturation, lightness, 1.0)
+    #[must_use]
+    pub const fn rgba(red: u8, green: u8, blue: u8, alpha: f32) -> Option<Self> {
+        Self::rgb(red, green, blue).with_alpha(alpha)
     }
 
-    /// Hsl with a given alpha
+    /// Hsl with opaque alpha. Constructs directly.
     #[inline]
-    pub const fn hsla(hue: u16, saturation: u8, lightness: u8, alpha: f32) -> Self {
-        debug_assert!(hue <= 360, "Hue should be in range 0-360");
-        debug_assert!(saturation <= 100, "saturation should be in range 0-100");
-        debug_assert!(lightness <= 100, "lightness should be in range 0-100");
-        debug_assert!(alpha <= 1.0 && alpha >= 0.0, "Alpha should be in range 0-1");
-
+    pub const fn hsl(hue: u16, saturation: u8, lightness: u8) -> Self {
         Self::Hsl {
             hue,
             saturation,
             lightness,
-            alpha,
+            alpha: 1.0,
         }
     }
 
-    /// Oklch with opaque alpha
+    /// Hsl with a given alpha. Returns None if any component is out of range.
+    /// Valid ranges: hue 0..=360, saturation 0..=100, lightness 0..=100, alpha 0.0..=1.0
+    #[inline]
+    #[must_use]
+    pub const fn hsla(hue: u16, saturation: u8, lightness: u8, alpha: f32) -> Option<Self> {
+        if hue > 360 {
+            return None;
+        }
+        if saturation > 100 {
+            return None;
+        }
+        if lightness > 100 {
+            return None;
+        }
+
+        Self::hsl(hue, saturation, lightness).with_alpha(alpha)
+    }
+
+    /// Oklch with opaque alpha. Constructs directly.
     #[inline]
     pub const fn oklch(lightness: f32, chroma: f32, hue: f32) -> Self {
         Self::Oklch {
@@ -139,26 +149,22 @@ impl Color {
         }
     }
 
-    /// Oklch with a given alpha
+    /// Oklch with a given alpha. Returns None if any component is out of range.
+    /// Valid ranges: lightness 0.0..=1.0, chroma 0.0..=1.0, hue 0.0..=1.0, alpha 0.0..=1.0
     #[inline]
-    pub const fn oklch_a(lightness: f32, chroma: f32, hue: f32, alpha: f32) -> Self {
-        debug_assert!(
-            lightness <= 1.0 && lightness >= 0.0,
-            "Lightness should be in range 0-1"
-        );
-        debug_assert!(
-            chroma <= 1.0 && chroma >= 0.0,
-            "chroma should be in range 0-1"
-        );
-        debug_assert!(hue <= 1.0 && hue >= 0.0, "hue should be in range 0-1");
-        debug_assert!(alpha <= 1.0 && alpha >= 0.0, "Alpha should be in range 0-1");
-
-        Self::Oklch {
-            lightness,
-            chroma,
-            hue,
-            alpha,
+    #[must_use]
+    pub const fn oklch_a(lightness: f32, chroma: f32, hue: f32, alpha: f32) -> Option<Self> {
+        if !(lightness >= 0.0 && lightness <= 1.0) {
+            return None;
         }
+        if !(chroma >= 0.0 && chroma <= 1.0) {
+            return None;
+        }
+        if !(hue >= 0.0 && hue <= 1.0) {
+            return None;
+        }
+
+        Self::oklch(lightness, chroma, hue).with_alpha(alpha)
     }
 }
 
@@ -191,6 +197,10 @@ impl IntoCss for Color {
             }
         }
     }
+}
+
+impl CssPropertyValue for Color {
+    type Kind = Color;
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
@@ -258,9 +268,18 @@ pub(crate) mod tests {
 
     #[test]
     fn snapshot_rgba_colors() {
-        assert_snapshot!("rgba_half_alpha", Color::rgba(255, 0, 0, 0.5).into_css());
-        assert_snapshot!("rgba_zero_alpha", Color::rgba(0, 255, 0, 0.0).into_css());
-        assert_snapshot!("rgba_full_alpha", Color::rgba(0, 0, 255, 1.0).into_css());
+        assert_snapshot!(
+            "rgba_half_alpha",
+            crate::const_unwrap!(Color::rgba(255, 0, 0, 0.5)).into_css()
+        );
+        assert_snapshot!(
+            "rgba_zero_alpha",
+            crate::const_unwrap!(Color::rgba(0, 255, 0, 0.0)).into_css()
+        );
+        assert_snapshot!(
+            "rgba_full_alpha",
+            crate::const_unwrap!(Color::rgba(0, 0, 255, 1.0)).into_css()
+        );
     }
 
     #[test]
@@ -273,9 +292,18 @@ pub(crate) mod tests {
 
     #[test]
     fn snapshot_hsla_colors() {
-        assert_snapshot!("hsla_half_alpha", Color::hsla(0, 100, 50, 0.5).into_css());
-        assert_snapshot!("hsla_zero_alpha", Color::hsla(120, 100, 50, 0.0).into_css());
-        assert_snapshot!("hsla_full_alpha", Color::hsla(240, 100, 50, 1.0).into_css());
+        assert_snapshot!(
+            "hsla_half_alpha",
+            crate::const_unwrap!(Color::hsla(0, 100, 50, 0.5)).into_css()
+        );
+        assert_snapshot!(
+            "hsla_zero_alpha",
+            crate::const_unwrap!(Color::hsla(120, 100, 50, 0.0)).into_css()
+        );
+        assert_snapshot!(
+            "hsla_full_alpha",
+            crate::const_unwrap!(Color::hsla(240, 100, 50, 1.0)).into_css()
+        );
     }
 
     #[test]
@@ -298,15 +326,15 @@ pub(crate) mod tests {
     fn snapshot_oklch_a_colors() {
         assert_snapshot!(
             "oklch_a_half_alpha",
-            Color::oklch_a(0.5, 0.1, 0.5, 0.5).into_css()
+            crate::const_unwrap!(Color::oklch_a(0.5, 0.1, 0.5, 0.5)).into_css()
         );
         assert_snapshot!(
             "oklch_a_zero_alpha",
-            Color::oklch_a(0.1, 0.2, 0.8, 0.0).into_css()
+            crate::const_unwrap!(Color::oklch_a(0.1, 0.2, 0.8, 0.0)).into_css()
         );
         assert_snapshot!(
             "oklch_a_full_alpha",
-            Color::oklch_a(0.9, 0.05, 0.2, 1.0).into_css()
+            crate::const_unwrap!(Color::oklch_a(0.9, 0.05, 0.2, 1.0)).into_css()
         );
     }
 
@@ -314,15 +342,15 @@ pub(crate) mod tests {
     fn snapshot_with_alpha_method() {
         assert_snapshot!(
             "with_alpha_rgb",
-            Color::rgb(10, 20, 30).with_alpha(0.75).into_css()
+            crate::const_unwrap!(Color::rgb(10, 20, 30).with_alpha(0.75)).into_css()
         );
         assert_snapshot!(
             "with_alpha_hsl",
-            Color::hsl(90, 50, 25).with_alpha(0.25).into_css()
+            crate::const_unwrap!(Color::hsl(90, 50, 25).with_alpha(0.25)).into_css()
         );
         assert_snapshot!(
             "with_alpha_oklch",
-            Color::oklch(0.3, 0.1, 0.6).with_alpha(0.9).into_css()
+            crate::const_unwrap!(Color::oklch(0.3, 0.1, 0.6).with_alpha(0.9)).into_css()
         );
     }
 

--- a/crates/natrix/src/lib.rs
+++ b/crates/natrix/src/lib.rs
@@ -59,6 +59,7 @@ pub mod prelude {
     pub use natrix_macros::State;
 
     pub use super::access::{Downgrade, Getter, Project, Ref, RefClosure};
+    pub use super::css::property::Variable;
     pub use super::css::selectors::{
         Class,
         Id,
@@ -74,7 +75,7 @@ pub mod prelude {
 }
 
 pub use dom::Element;
-pub use natrix_macros::{State, asset, data, format_elements};
+pub use natrix_macros::{State, asset, format_elements};
 pub use reactivity::mount::mount;
 pub use reactivity::state::{EventCtx, RenderCtx};
 

--- a/crates/natrix/src/reactivity/state/hook_manager.rs
+++ b/crates/natrix/src/reactivity/state/hook_manager.rs
@@ -45,8 +45,10 @@ impl HookKey {
 }
 
 /// The value of a slot
+#[derive(Default)]
 enum SlotValue<T> {
     /// The slot doesnt contain a value
+    #[default]
     Empty,
     /// The slot is in use, but the value is moved out atm
     InUse,
@@ -62,12 +64,6 @@ enum SlotValue<T> {
         /// The insertion order
         order: InsertionOrder,
     },
-}
-
-impl<T> Default for SlotValue<T> {
-    fn default() -> Self {
-        Self::Empty
-    }
 }
 
 /// A slot in the slotmap

--- a/crates/natrix_macros/src/lib.rs
+++ b/crates/natrix_macros/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::{fs, io};
 
 use proc_macro2::TokenStream;
-use quote::{ToTokens, format_ident, quote};
+use quote::{ToTokens, quote};
 
 /// Create a array of elements based on the format string.
 /// The start of the macro is a closure argument list, which should generally be `|ctx: R<Self>|`

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1754549159,
-        "narHash": "sha256-47e1Ar09kZlv2HvZilaNRFzRybIiJYNQ2MSvofbiw5o=",
+        "lastModified": 1757831996,
+        "narHash": "sha256-vLvo3VmGXA+mvra90asjpZTdjElDOZB62xuQP31pO2s=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "5fe110751342a023d8c7ddce7fbf8311dca9f58d",
+        "rev": "7b679aa06678433ff15df49c9fc50671fc4fc4cc",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754214453,
-        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
+        "lastModified": 1757745802,
+        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
+        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754562534,
-        "narHash": "sha256-8tP2Jj1SA55zpp4SUl3bzeEDZWUiswQulGYMrOzxXpw=",
+        "lastModified": 1757863705,
+        "narHash": "sha256-XV74BO+MPnrRb/btERHmwBZuXCLsvIe9Gxw8ocgBLCE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e2b0a54f3538a26b983ab3fe7fa2bdbf466621cd",
+        "rev": "8de27b6789546d3278ebfab3b74dbf8951fdea1e",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1754496778,
-        "narHash": "sha256-fPDLP3z9XaYQBfSCemEdloEONz/uPyr35RHPRy9Vx8M=",
+        "lastModified": 1757362324,
+        "narHash": "sha256-/PAhxheUq4WBrW5i/JHzcCqK5fGWwLKdH6/Lu1tyS18=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "529d3b935d68bdf9120fe4d7f8eded7b56271697",
+        "rev": "9edc9cbe5d8e832b5864e09854fa94861697d2fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
closes #57 
closes #54 

This pull request introduces a significant refactor and extension of the CSS property value system in the `natrix` crate. The core change is the introduction of a new `CssPropertyValue` trait, which unifies and type-tracks valid CSS property values, enabling better support for CSS variables, improved type safety, and extensibility for custom property kinds. The update also migrates all built-in CSS value types (such as numerics, enums, and tuples) to implement this new trait, and adds new types for CSS variables and lengths.

Key changes:

### CSS Property Value System Refactor

* Introduced the `CssPropertyValue` trait in `values.rs` to represent types that can be used as CSS property values, along with an associated `Kind` type for type-level tracking. All relevant CSS value types (including numerics, enums, tuples, and newtypes) now implement this trait. [[1]](diffhunk://#diff-e310ca648f1a25d31fb3d2e645583d93e37b0e7bbd86fbda3083b9ae70697721R18-R34) [[2]](diffhunk://#diff-e310ca648f1a25d31fb3d2e645583d93e37b0e7bbd86fbda3083b9ae70697721R45-R47) [[3]](diffhunk://#diff-e310ca648f1a25d31fb3d2e645583d93e37b0e7bbd86fbda3083b9ae70697721R57-R59) [[4]](diffhunk://#diff-e310ca648f1a25d31fb3d2e645583d93e37b0e7bbd86fbda3083b9ae70697721R109-R112) [[5]](diffhunk://#diff-e310ca648f1a25d31fb3d2e645583d93e37b0e7bbd86fbda3083b9ae70697721R135-R177) [[6]](diffhunk://#diff-e310ca648f1a25d31fb3d2e645583d93e37b0e7bbd86fbda3083b9ae70697721R260-R263) [[7]](diffhunk://#diff-f6265d06198fd345eb88c6a99b9945674960c402fd01fce2949b32adde0d9934R7) [[8]](diffhunk://#diff-f6265d06198fd345eb88c6a99b9945674960c402fd01fce2949b32adde0d9934R134-R140) [[9]](diffhunk://#diff-346ce7754889288496b4f3ba8ee57b825ac538e599c6c62750634211ffcec4f3L2-R135)
* Updated the property system in `property.rs` to use `CssPropertyValue` instead of the previous `IntoCss`-only approach, including updating the `set` method and property macro to require the correct kind of value. [[1]](diffhunk://#diff-fe16cbf99081ac8c3bc91c55c24b1472253fa1d1e6bd605ca3fec568aaf617dfR3-R7) [[2]](diffhunk://#diff-fe16cbf99081ac8c3bc91c55c24b1472253fa1d1e6bd605ca3fec568aaf617dfL78-R81) [[3]](diffhunk://#diff-fe16cbf99081ac8c3bc91c55c24b1472253fa1d1e6bd605ca3fec568aaf617dfL133-R190)

### CSS Variable Support

* Added a new generic `Variable<K>` type and a `css_var!` macro for defining and using CSS variables in a type-safe way. Variables are now first-class citizens in the property system and participate in type checking.
* Re-exported `Variable` in the `prelude` for easier use.

### Built-in Value Types and Macros

* Refactored wide keywords to be generic over their kind, and ensured all built-in value enums and zero-sized values implement `CssPropertyValue`.
* Added or updated implementations for tuples and collections (e.g., `(A, B)`, `Vec<Animation>`) to implement `CssPropertyValue` with the correct kind. [[1]](diffhunk://#diff-e310ca648f1a25d31fb3d2e645583d93e37b0e7bbd86fbda3083b9ae70697721R57-R59) [[2]](diffhunk://#diff-f6265d06198fd345eb88c6a99b9945674960c402fd01fce2949b32adde0d9934R134-R140)

### Numeric and Unit Types

* Added new types for CSS angles and lengths, implemented as enums, and ensured they implement `CssPropertyValue`. The `unit!` macro was removed in favor of these new types.

### Macro and Test Updates

* Updated macros and test utilities to work with the new type system, including a new `support_no_test!` macro for properties with generic kinds. [[1]](diffhunk://#diff-fe16cbf99081ac8c3bc91c55c24b1472253fa1d1e6bd605ca3fec568aaf617dfL168-R231) [[2]](diffhunk://#diff-fe16cbf99081ac8c3bc91c55c24b1472253fa1d1e6bd605ca3fec568aaf617dfL206-R285) [[3]](diffhunk://#diff-1be595c55b2f30a0f080b036eaa7245a00f80f5ed8e261b432d7f6eedfd1cdc4L276-R276)
* Minor cleanup in macro imports and usage. [[1]](diffhunk://#diff-08a4c4408679052edf53a141e5c4117860c61e6b1872a85001bc485c58844e11L12-R12) [[2]](diffhunk://#diff-276e858c78b77b1990deb5dcb10a72af91e0bd7c4a95e763dbfd68eb493aa161L77-R78)

These changes collectively make the CSS property system more robust, extensible, and type-safe, paving the way for advanced features like type-safe variables and custom property kinds.