### PR TITLE
Update repository links from vivax3794/natrix to Serpent-Tools/natrix

### DIFF
--- a/crates/natrix/Cargo.toml
+++ b/crates/natrix/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 description = "Rust-First frontend framework."
 license = "MIT"
-repository = "https://github.com/vivax3794/natrix"
+repository = "https://github.com/Serpent-Tools/natrix"
 keywords = ["frontend", "framework", "web", "wasm"]
 categories = ["gui", "wasm", "web-programming"]
 

--- a/crates/natrix/src/dom/html_elements.rs
+++ b/crates/natrix/src/dom/html_elements.rs
@@ -122,7 +122,7 @@ impl<C: State, T> HtmlElement<C, T> {
     /// })
     /// # }
     /// ```
-    /// For more information see [Reactivity](https://vivax3794.github.io/natrix/reactivity.html) in the book.
+    /// For more information see [Reactivity](https://serpent-tools.github.io/natrix/reactivity.html) in the book.
     #[inline]
     pub fn on<E: Event>(mut self, function: impl EventHandler<C, E>) -> Self {
         let function = function.func();

--- a/crates/natrix_macros/Cargo.toml
+++ b/crates/natrix_macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 description = "Macros for natrix"
 license = "MIT"
-repository = "https://github.com/vivax3794/natrix"
+repository = "https://github.com/Serpent-Tools/natrix"
 
 [lints]
 workspace = true

--- a/crates/natrix_macros/src/lib.rs
+++ b/crates/natrix_macros/src/lib.rs
@@ -1,4 +1,4 @@
-//! Derive macros for [Natrix](https://github.com/vivax3794/natrix)
+//! Derive macros for [Natrix](https://github.com/Serpent-Tools/natrix)
 
 extern crate proc_macro;
 

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,6 +1,6 @@
 # Introduction 
 
-<img src="https://github.com/vivax3794/natrix/raw/master/assets/logo.png" alt="Logo" width="300" height="300">
+<img src="https://github.com/Serpent-Tools/natrix/raw/master/assets/logo.png" alt="Logo" width="300" height="300">
 
 
 Natrix is a ***Rust-first*** frontend framework. Embracing Rust’s strengths—leveraging smart pointers, derive macros, the builder pattern, and other idiomatic Rust features to create a truly native experience.

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,6 +1,6 @@
 # Introduction 
 
-<img src="https://github.com/Serpent-Tools/natrix/raw/master/assets/logo.png" alt="Logo" width="300" height="300">
+<img src="https://raw.githubusercontent.com/Serpent-Tools/branding/refs/heads/main/natrix.svg" alt="Logo" width="300" height="300">
 
 
 Natrix is a ***Rust-first*** frontend framework. Embracing Rust’s strengths—leveraging smart pointers, derive macros, the builder pattern, and other idiomatic Rust features to create a truly native experience.


### PR DESCRIPTION
# Update repository links from vivax3794/natrix to Serpent-Tools/natrix

## Description

This PR updates all repository links throughout the codebase to reflect the new organization structure, changing references from `vivax3794/natrix` to `Serpent-Tools/natrix`.

## Changes Made

### Files Updated (5 files total):

1. **`crates/natrix/Cargo.toml`**
   - Updated `repository` field from `https://github.com/vivax3794/natrix` to `https://github.com/Serpent-Tools/natrix`

2. **`crates/natrix_macros/Cargo.toml`**
   - Updated `repository` field from `https://github.com/vivax3794/natrix` to `https://github.com/Serpent-Tools/natrix`

3. **`crates/natrix_macros/src/lib.rs`**
   - Updated documentation link in crate-level comment from `https://github.com/vivax3794/natrix` to `https://github.com/Serpent-Tools/natrix`

4. **`crates/natrix/src/dom/html_elements.rs`**
   - Updated documentation URL from `https://vivax3794.github.io/natrix/reactivity.html` to `https://serpent-tools.github.io/natrix/reactivity.html`

5. **`docs/src/README.md`**
   - Updated logo image URL from `https://github.com/vivax3794/natrix/raw/master/assets/logo.png` to `https://github.com/Serpent-Tools/natrix/raw/master/assets/logo.png`

## Impact

- **Repository consistency**: All links now point to the correct organization
- **Documentation accuracy**: Users will be directed to the correct repository and documentation
- **Package metadata**: Cargo.toml files now have accurate repository information
- **No functional changes**: This is purely a URL update with no impact on code functionality

## Verification

- ✅ Searched entire codebase for any remaining `vivax3794/natrix` references - none found
- ✅ Verified all new `Serpent-Tools/natrix` links are correctly in place
- ✅ No linting errors introduced
- ✅ All changes are minimal and focused on URL updates only

## Related

Fixes #92

## Testing

No testing required as this only updates URLs and metadata. The changes are:
- Repository links in Cargo.toml files
- Documentation links in source code comments
- Image URLs in markdown files

All changes maintain the same functionality while pointing to the correct repository location.